### PR TITLE
Fix tf_cloudflare build on OCaml 5.4 (effect keyword)

### DIFF
--- a/bin/gen.ml
+++ b/bin/gen.ml
@@ -122,6 +122,7 @@ let to_ocaml_name = function
   | "class" -> "class_"
   | "constraint" -> "constraint_"
   | "end" -> "end_"
+  | "effect" -> "effect_"
   | "external" -> "external_"
   | "for" -> "for_"
   | "function" -> "function_"

--- a/providers/cloudflare/cloudflare_api_token.ml
+++ b/providers/cloudflare/cloudflare_api_token.ml
@@ -75,7 +75,7 @@ let _ = yojson_of_condition
 [@@@deriving.end]
 
 type policy = {
-  effect : string prop option; [@option]
+  effect_ : string prop option; [@option] [@key "effect"]
   permission_groups : string prop list;
       [@default []] [@yojson_drop_default Stdlib.( = )]
   resources : string prop Tf_core.assoc;
@@ -87,7 +87,7 @@ let _ = fun (_ : policy) -> ()
 let yojson_of_policy =
   (function
    | {
-       effect = v_effect;
+       effect_ = v_effect_;
        permission_groups = v_permission_groups;
        resources = v_resources;
      } ->
@@ -113,7 +113,7 @@ let yojson_of_policy =
            bnd :: bnds
        in
        let bnds =
-         match v_effect with
+         match v_effect_ with
          | Ppx_yojson_conv_lib.Option.None -> bnds
          | Ppx_yojson_conv_lib.Option.Some v ->
              let arg = yojson_of_prop yojson_of_string v in
@@ -210,8 +210,8 @@ let condition__request_ip ?in_ ?not_in () : condition__request_ip =
 
 let condition ?(request_ip = []) () : condition = { request_ip }
 
-let policy ?effect ~permission_groups ~resources () : policy =
-  { effect; permission_groups; resources }
+let policy ?effect_ ~permission_groups ~resources () : policy =
+  { effect_; permission_groups; resources }
 
 let cloudflare_api_token ?expires_on ?id ?not_before
     ?(condition = []) ~name ~policy () : cloudflare_api_token =

--- a/providers/cloudflare/cloudflare_api_token.ml
+++ b/providers/cloudflare/cloudflare_api_token.ml
@@ -87,7 +87,7 @@ let _ = fun (_ : policy) -> ()
 let yojson_of_policy =
   (function
    | {
-       effect_ = v_effect_;
+       effect_ = v_effect;
        permission_groups = v_permission_groups;
        resources = v_resources;
      } ->
@@ -113,7 +113,7 @@ let yojson_of_policy =
            bnd :: bnds
        in
        let bnds =
-         match v_effect_ with
+         match v_effect with
          | Ppx_yojson_conv_lib.Option.None -> bnds
          | Ppx_yojson_conv_lib.Option.Some v ->
              let arg = yojson_of_prop yojson_of_string v in

--- a/providers/cloudflare/cloudflare_api_token.mli
+++ b/providers/cloudflare/cloudflare_api_token.mli
@@ -1,8 +1,9 @@
 (** Provides a resource which manages Cloudflare API tokens.
 
-Read more about permission groups and their applicable scopes in the
-[developer documentation](https://developers.cloudflare.com/api/tokens/create/permissions).
- *)
+    Read more about permission groups and their applicable scopes in
+    the
+    [developer documentation](https://developers.cloudflare.com/api/tokens/create/permissions).
+*)
 
 (* DO NOT EDIT, GENERATED AUTOMATICALLY *)
 
@@ -26,7 +27,7 @@ val condition :
 type policy
 
 val policy :
-  ?effect:string prop ->
+  ?effect_:string prop ->
   permission_groups:string prop list ->
   resources:string prop Tf_core.assoc ->
   unit ->


### PR DESCRIPTION
- treat `effect` as a reserved OCaml identifier in the generator (`effect` -> `effect_`),  matters on 5.4 where `effect` is a keyword
- regenerate the affected Cloudflare API token binding so field names stay serialized as `"effect"`
