### PR TITLE
Update dependencies to require yojson version 3.0.0

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -16,60 +16,60 @@
 (package
  (name tf)
  (synopsis "Define terraform/opentofu configuration with OCaml")
- (depends ocaml dune containers yojson ppx_yojson_conv_lib cmdliner))
+ (depends ocaml dune containers (yojson >= 3.0.0) ppx_yojson_conv_lib cmdliner))
 
 (package
  (name tf_digitalocean)
  (synopsis "Generated bindings to DigitalOcean terraform/opentofu provider")
- (depends tf ocaml dune containers yojson ppx_yojson_conv_lib))
+ (depends tf ocaml dune containers (yojson >= 3.0.0) ppx_yojson_conv_lib))
 
 (package
  (name tf_cloudflare)
  (synopsis "Generated bindings to CloudFlare terraform/opentofu provider")
- (depends tf ocaml dune containers yojson ppx_yojson_conv_lib))
+ (depends tf ocaml dune containers (yojson >= 3.0.0) ppx_yojson_conv_lib))
 
 (package
  (name tf_azurerm)
  (synopsis "Generated bindings to Azure RM terraform/opentofu provider")
- (depends tf ocaml dune containers yojson ppx_yojson_conv_lib))
+ (depends tf ocaml dune containers (yojson >= 3.0.0) ppx_yojson_conv_lib))
 
 (package
  (name tf_google)
  (synopsis "Generated bindings to Google terraform/opentofu provider")
- (depends tf ocaml dune containers yojson ppx_yojson_conv_lib))
+ (depends tf ocaml dune containers (yojson >= 3.0.0) ppx_yojson_conv_lib))
 
 (package
  (name tf_kubernetes)
  (synopsis "Generated bindings to Kubernetes terraform/opentofu provider")
- (depends tf ocaml dune containers yojson ppx_yojson_conv_lib))
+ (depends tf ocaml dune containers (yojson >= 3.0.0) ppx_yojson_conv_lib))
 
 (package
  (name tf_hcloud)
  (synopsis "Generated bindings to Hetzner Cloud terraform/opentofu provider")
- (depends tf ocaml dune containers yojson ppx_yojson_conv_lib))
+ (depends tf ocaml dune containers (yojson >= 3.0.0) ppx_yojson_conv_lib))
 
 (package
  (name tf_aws)
  (synopsis "Generated bindings to AWS terraform/opentofu provider")
- (depends tf ocaml dune containers yojson ppx_yojson_conv_lib))
+ (depends tf ocaml dune containers (yojson >= 3.0.0) ppx_yojson_conv_lib))
 
 (package
  (name tf_github)
  (synopsis "Generated bindings to GitHub terraform/opentofu provider")
- (depends tf ocaml dune containers yojson ppx_yojson_conv_lib))
+ (depends tf ocaml dune containers (yojson >= 3.0.0) ppx_yojson_conv_lib))
 
 (package
  (name tf_okta)
  (synopsis "Generated bindings to Okta terraform/opentofu provider")
- (depends tf ocaml dune containers yojson ppx_yojson_conv_lib))
+ (depends tf ocaml dune containers (yojson >= 3.0.0) ppx_yojson_conv_lib))
 
 (package
  (name tf_dnsimple)
  (synopsis "Generated bindings to DNSimple terraform/opentofu provider")
- (depends tf ocaml dune containers yojson ppx_yojson_conv_lib))
+ (depends tf ocaml dune containers (yojson >= 3.0.0) ppx_yojson_conv_lib))
 
 (package
  (name tf_vault)
  (synopsis
   "Generated bindings to Hashicorp Vault terraform/opentofu provider")
- (depends tf ocaml dune containers yojson ppx_yojson_conv_lib))
+ (depends tf ocaml dune containers (yojson >= 3.0.0) ppx_yojson_conv_lib))

--- a/tf/tf_core.ml
+++ b/tf/tf_core.ml
@@ -260,10 +260,9 @@ module Prop = struct
                   Printf.sprintf "%s = %s" k (json_to_hcl v))))
     | `Float f -> string_of_float f
     | `Bool b -> string_of_bool b
-    | `Tuple xs | `List xs ->
+    | `List xs ->
         Printf.sprintf "[%s]"
           (String.concat ~sep:", " (List.map xs ~f:string_of_yojson))
-    | `Variant _ -> failwith "didn't expect `Variant"
 end
 
 type 'a prop = 'a Prop.t

--- a/tf/tf_run.ml
+++ b/tf/tf_run.ml
@@ -45,12 +45,7 @@ let rec json_to_ml ppf (json : Yojson.Safe.t) =
       Format.fprintf ppf "@[<hv 2>[%a]@]"
         (Format.pp_print_list pp_assoc)
         xs
-  | `Tuple xs ->
-      Format.fprintf ppf "@[<hv 2>(%a)@]"
-        (Format.pp_print_list json_to_ml)
-        xs
   | `Intlit v -> Format.fprintf ppf "%s" v
-  | `Variant _ -> assert false
 
 let run () =
   let variables_t =


### PR DESCRIPTION
## Update yojson dependency to v3.0.0+

Bumps the minimum required version of yojson to >= 3.0.0 across all packages in dune-project. Yojson 3.0 removed the `Tuple and `Variant constructors from Yojson.Safe.t, so the corresponding match arms in tf_core.ml and tf_run.ml are also removed.

